### PR TITLE
fix: lock down copilot provider tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build test fmt vet lint clean run
+.PHONY: help build test fmt vet lint clean run release
 
 # Default target
 help:
@@ -10,6 +10,7 @@ help:
 	@echo "  make lint     - Run golangci-lint (if installed)"
 	@echo "  make clean    - Remove build artifacts"
 	@echo "  make run      - Run the main application"
+	@echo "  make release  - Create and push a release tag (VERSION=x.y.z)"
 
 # Build the project
 build:
@@ -17,7 +18,7 @@ build:
 
 # Run tests
 test:
-	go test -v -race -coverprofile=coverage.out ./...
+	go test -v -race ./...
 
 # Format code
 fmt:
@@ -40,3 +41,18 @@ clean:
 # Run the main application (adjust path as needed)
 run:
 	go run ./...
+
+releases:
+	git tag --list
+
+# Create and push a release tag
+# Usage: make release VERSION=v1.0.0
+release: fmt vet test
+ifndef VERSION
+	@echo "Error: VERSION not specified. Usage: make release VERSION=vX.Y.Z"
+	@exit 1
+endif
+	@echo "Creating release tag: $(VERSION)"
+	git tag -a $(VERSION) -m "Release $(VERSION)"
+	git push origin $(VERSION)
+	@echo "Release $(VERSION) created and pushed successfully"

--- a/providers/github-copilot/chat.go
+++ b/providers/github-copilot/chat.go
@@ -19,6 +19,41 @@ import (
 // Ensure ChatModel implements llms.ChatModel.
 var _ llms.ChatModel = (*ChatModel)(nil)
 
+var copilotBuiltInToolNames = []string{
+	"bash",
+	"powershell",
+	"read_bash",
+	"read_powershell",
+	"write_bash",
+	"write_powershell",
+	"stop_bash",
+	"stop_powershell",
+	"list_bash",
+	"list_powershell",
+	"view",
+	"create",
+	"edit",
+	"apply_patch",
+	"task",
+	"read_agent",
+	"list_agents",
+	"grep",
+	"rg",
+	"glob",
+	"web_fetch",
+	"skill",
+	"ask_user",
+	"report_intent",
+	"show_file",
+	"fetch_copilot_cli_documentation",
+	"update_todo",
+	"store_memory",
+	"task_complete",
+	"exit_plan_mode",
+	"sql",
+	"lsp",
+}
+
 // ChatModel is the GitHub Copilot chat model implementation backed by the Copilot SDK.
 type ChatModel struct {
 	opts             *Options
@@ -44,15 +79,7 @@ func New(ctx context.Context, optFns ...OptionFunc) (*ChatModel, error) {
 		}
 	}
 
-	clientOpts := &copilot.ClientOptions{
-		LogLevel: opts.LogLevel,
-	}
-	if opts.GithubToken != "" {
-		clientOpts.GitHubToken = opts.GithubToken
-	}
-	if opts.CLIPath != "" {
-		clientOpts.CLIPath = opts.CLIPath
-	}
+	clientOpts := buildClientOptions(opts)
 
 	client := copilot.NewClient(clientOpts)
 	if err := client.Start(ctx); err != nil {
@@ -331,6 +358,8 @@ func (m *ChatModel) buildSessionConfig(ctx context.Context, messages []core.Mess
 			Parameters:  td.Parameters,
 		})
 	}
+	sessionCfg.AvailableTools = toolNames(sdkTools)
+	sessionCfg.ExcludedTools = builtInToolNames()
 
 	if len(sdkTools) > 0 {
 		sessionCfg.Tools = sdkTools
@@ -342,6 +371,44 @@ func (m *ChatModel) buildSessionConfig(ctx context.Context, messages []core.Mess
 	}
 
 	return sessionCfg
+}
+
+func buildClientOptions(opts *Options) *copilot.ClientOptions {
+	clientOpts := &copilot.ClientOptions{
+		CLIArgs:  defaultCLIArgs(),
+		LogLevel: opts.LogLevel,
+	}
+	if opts.GithubToken != "" {
+		clientOpts.GitHubToken = opts.GithubToken
+	}
+	if opts.CLIPath != "" {
+		clientOpts.CLIPath = opts.CLIPath
+	}
+	return clientOpts
+}
+
+func defaultCLIArgs() []string {
+	return []string{"--disable-builtin-mcps"}
+}
+
+func builtInToolNames() []string {
+	return append([]string(nil), copilotBuiltInToolNames...)
+}
+
+func toolNames(tools []copilot.Tool) []string {
+	names := make([]string, 0, len(tools))
+	seen := make(map[string]struct{}, len(tools))
+	for _, tool := range tools {
+		if tool.Name == "" {
+			continue
+		}
+		if _, ok := seen[tool.Name]; ok {
+			continue
+		}
+		seen[tool.Name] = struct{}{}
+		names = append(names, tool.Name)
+	}
+	return names
 }
 
 // bridgeTools converts langchain Tool implementations to copilot.Tool structs

--- a/providers/github-copilot/chat.go
+++ b/providers/github-copilot/chat.go
@@ -358,6 +358,10 @@ func (m *ChatModel) buildSessionConfig(ctx context.Context, messages []core.Mess
 			Parameters:  td.Parameters,
 		})
 	}
+
+	// De-duplicate tools by name, preferring entries with handlers (from bridged tools).
+	sdkTools = deduplicateTools(sdkTools)
+
 	sessionCfg.AvailableTools = toolNames(sdkTools)
 	sessionCfg.ExcludedTools = builtInToolNames()
 
@@ -460,6 +464,42 @@ func bridgeTools(ctx context.Context, langchainTools []tools.Tool) []copilot.Too
 	}
 
 	return sdkTools
+}
+
+// deduplicateTools removes duplicate tool entries by name, preferring tools with
+// non-nil handlers (which are the bridged tools with executable implementations).
+func deduplicateTools(tools []copilot.Tool) []copilot.Tool {
+	seen := make(map[string]copilot.Tool)
+
+	// First pass: collect all tools by name, prioritizing those with handlers.
+	for _, tool := range tools {
+		if tool.Name == "" {
+			continue
+		}
+		existing, found := seen[tool.Name]
+		// Keep the tool if:
+		// 1. We haven't seen this name yet, OR
+		// 2. The new tool has a handler and the existing one doesn't
+		if !found || (tool.Handler != nil && existing.Handler == nil) {
+			seen[tool.Name] = tool
+		}
+	}
+
+	// Second pass: rebuild the tools slice preserving order of first occurrence.
+	result := make([]copilot.Tool, 0, len(seen))
+	seenOrder := make(map[string]struct{})
+	for _, tool := range tools {
+		if tool.Name == "" {
+			continue
+		}
+		if _, ok := seenOrder[tool.Name]; ok {
+			continue
+		}
+		seenOrder[tool.Name] = struct{}{}
+		result = append(result, seen[tool.Name])
+	}
+
+	return result
 }
 
 // extractSystemMessage finds the first system message content.

--- a/providers/github-copilot/chat_test.go
+++ b/providers/github-copilot/chat_test.go
@@ -56,6 +56,28 @@ func TestGetName(t *testing.T) {
 	}
 }
 
+func TestBuildClientOptions(t *testing.T) {
+	opts := DefaultOptions()
+	opts.GithubToken = "test-token"
+	opts.CLIPath = "/usr/local/bin/copilot"
+	opts.LogLevel = "debug"
+
+	clientOpts := buildClientOptions(opts)
+
+	if clientOpts.LogLevel != "debug" {
+		t.Fatalf("expected log level 'debug', got %q", clientOpts.LogLevel)
+	}
+	if clientOpts.GitHubToken != "test-token" {
+		t.Fatalf("expected GitHub token to be forwarded, got %q", clientOpts.GitHubToken)
+	}
+	if clientOpts.CLIPath != "/usr/local/bin/copilot" {
+		t.Fatalf("expected CLI path to be forwarded, got %q", clientOpts.CLIPath)
+	}
+	if len(clientOpts.CLIArgs) != 1 || clientOpts.CLIArgs[0] != "--disable-builtin-mcps" {
+		t.Fatalf("expected built-in MCP restriction CLI args, got %v", clientOpts.CLIArgs)
+	}
+}
+
 func TestBindTools(t *testing.T) {
 	model := &ChatModel{opts: DefaultOptions()}
 
@@ -270,6 +292,18 @@ func TestBuildSessionConfig(t *testing.T) {
 		if sessionCfg.InfiniteSessions == nil || *sessionCfg.InfiniteSessions.Enabled {
 			t.Error("expected infinite sessions to be disabled")
 		}
+		if sessionCfg.AvailableTools == nil {
+			t.Fatal("expected available tools allowlist to be set")
+		}
+		if len(sessionCfg.AvailableTools) != 0 {
+			t.Errorf("expected no available tools, got %v", sessionCfg.AvailableTools)
+		}
+		if !stringSliceContains(sessionCfg.ExcludedTools, "web_fetch") {
+			t.Fatalf("expected web_fetch to be excluded by default, got %v", sessionCfg.ExcludedTools)
+		}
+		if !stringSliceContains(sessionCfg.ExcludedTools, "task") {
+			t.Fatalf("expected task to be excluded by default, got %v", sessionCfg.ExcludedTools)
+		}
 	})
 
 	t.Run("with system message", func(t *testing.T) {
@@ -339,6 +373,75 @@ func TestBuildSessionConfig(t *testing.T) {
 		}
 		if sessionCfg.Tools[0].Name != "calculator" {
 			t.Errorf("expected tool name 'calculator', got %q", sessionCfg.Tools[0].Name)
+		}
+		if len(sessionCfg.AvailableTools) != 1 || sessionCfg.AvailableTools[0] != "calculator" {
+			t.Errorf("expected available tools [calculator], got %v", sessionCfg.AvailableTools)
+		}
+	})
+
+	t.Run("with explicit bridged tools", func(t *testing.T) {
+		model := &ChatModel{
+			opts: &Options{
+				Model: "gpt-5-mini",
+				Tools: []tools.Tool{
+					&mockTool{
+						name:        "weather",
+						description: "Gets weather",
+						schema:      map[string]any{"type": "object"},
+						runFunc: func(ctx context.Context, input string) (string, error) {
+							return "sunny", nil
+						},
+					},
+				},
+			},
+		}
+
+		messages := []core.Message{core.NewHumanMessage("hello")}
+		cfg := core.DefaultConfig()
+
+		sessionCfg := model.buildSessionConfig(ctx, messages, cfg)
+
+		if len(sessionCfg.Tools) != 1 {
+			t.Fatalf("expected 1 tool, got %d", len(sessionCfg.Tools))
+		}
+		if sessionCfg.Tools[0].Name != "weather" {
+			t.Errorf("expected tool name 'weather', got %q", sessionCfg.Tools[0].Name)
+		}
+		if sessionCfg.Tools[0].Handler == nil {
+			t.Fatal("expected bridged tool handler to be set")
+		}
+		if len(sessionCfg.AvailableTools) != 1 || sessionCfg.AvailableTools[0] != "weather" {
+			t.Errorf("expected available tools [weather], got %v", sessionCfg.AvailableTools)
+		}
+	})
+
+	t.Run("deduplicates available tools", func(t *testing.T) {
+		model := &ChatModel{
+			opts: &Options{
+				Model: "gpt-5-mini",
+				Tools: []tools.Tool{
+					&mockTool{
+						name:        "calculator",
+						description: "Does math",
+						schema:      map[string]any{"type": "object"},
+						runFunc: func(ctx context.Context, input string) (string, error) {
+							return "42", nil
+						},
+					},
+				},
+			},
+			boundTools: []llms.ToolDefinition{
+				{Name: "calculator", Description: "Does math", Parameters: map[string]any{"type": "object"}},
+			},
+		}
+
+		messages := []core.Message{core.NewHumanMessage("hello")}
+		cfg := core.DefaultConfig()
+
+		sessionCfg := model.buildSessionConfig(ctx, messages, cfg)
+
+		if len(sessionCfg.AvailableTools) != 1 || sessionCfg.AvailableTools[0] != "calculator" {
+			t.Errorf("expected deduplicated available tools [calculator], got %v", sessionCfg.AvailableTools)
 		}
 	})
 
@@ -647,6 +750,15 @@ func contains(s, substr string) bool {
 func containsHelper(s, substr string) bool {
 	for i := 0; i <= len(s)-len(substr); i++ {
 		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+func stringSliceContains(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
 			return true
 		}
 	}

--- a/providers/github-copilot/options.go
+++ b/providers/github-copilot/options.go
@@ -38,7 +38,9 @@ type Options struct {
 	Stop []string
 
 	// Tools are langchain Tool implementations that get bridged to SDK tool handlers.
-	// When set, the SDK manages the full tool-calling loop internally.
+	// Only these tools, plus any llms.ToolDefinition values bound via BindTools,
+	// are exposed to the Copilot session. Built-in Copilot CLI tools are disabled
+	// by default.
 	Tools []tools.Tool
 
 	// ReasoningEffort controls the effort the model spends on reasoning.
@@ -92,7 +94,8 @@ func WithMaxConcurrency(n int) OptionFunc {
 
 // WithTools sets langchain Tool implementations that get bridged to SDK tool handlers.
 // The SDK manages the full tool-calling loop internally, so Invoke returns the
-// final response after all tool calls are resolved.
+// final response after all tool calls are resolved. The Copilot session only
+// exposes explicitly configured tools.
 func WithTools(t ...tools.Tool) OptionFunc {
 	return func(o *Options) { o.Tools = append(o.Tools, t...) }
 }

--- a/providers/ollama/chat_test.go
+++ b/providers/ollama/chat_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/LucaLanziani/langchain-go/core"
@@ -374,12 +375,16 @@ func TestStream_ToolCalls(t *testing.T) {
 // ---------- ChatModel.Batch ----------
 
 func TestBatch(t *testing.T) {
+	var mu sync.Mutex
 	callCount := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		callCount++
+		count := callCount
+		mu.Unlock()
 		jsonResponse(t, w, chatResponse{
 			Done:    true,
-			Message: ollamaMessage{Role: "assistant", Content: fmt.Sprintf("response %d", callCount)},
+			Message: ollamaMessage{Role: "assistant", Content: fmt.Sprintf("response %d", count)},
 		})
 	}))
 	defer srv.Close()
@@ -396,9 +401,11 @@ func TestBatch(t *testing.T) {
 	if len(results) != 3 {
 		t.Errorf("expected 3 results, got %d", len(results))
 	}
+	mu.Lock()
 	if callCount != 3 {
 		t.Errorf("expected 3 API calls, got %d", callCount)
 	}
+	mu.Unlock()
 }
 
 // ---------- ChatModel.BindTools ----------


### PR DESCRIPTION
This change makes GitHub Copilot provider tool availability explicit and closes the gap where built-in Copilot CLI capabilities could still be used even when no external tools were passed in.

What changed:

- The provider now only exposes tools that are passed in explicitly or bound through langchain-go.
- Copilot session configuration now sets an explicit allowlist for surfaced tools.
- Built-in CLI tools such as web_fetch, task, read_agent, and list_agents are excluded by default.
- Built-in MCP servers are disabled when the Copilot CLI process starts.
- Existing provider behavior was checked across OpenAI, Anthropic, and Ollama, which were already explicit about tool exposure.


Why:

- Session-level tool binding alone was not sufficient for the Copilot CLI runtime.
- The CLI has its own documented built-in tools and delegation paths, including web_fetch and task.
- This change aligns GitHub Copilot with the intended security model: only caller-provided tools should be available by default.


Testing:

- go test ./providers/github-copilot ./provider